### PR TITLE
Add package requirements list

### DIFF
--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -1,0 +1,11 @@
+# These are the direct package dependencies
+beautifulsoup4==4.12.2
+lyricsgenius==3.0.1
+pyperclip==1.8.2
+requests==2.31.0
+# These are the transitive package dependencies from the direct dependencies
+certifi==2023.11.17
+charset-normalizer==3.3.2
+idna==3.4
+soupsieve==2.5
+urllib3==2.1.0


### PR DESCRIPTION
To allow for easier setup of a Python environment to run the main script. The only command needed for setup is:
`pip install -r REQUIREMENTS.txt` 