### PR TITLE
Use meaningless for Bible passage extraction

### DIFF
--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -1,11 +1,15 @@
 # These are the direct package dependencies
 beautifulsoup4==4.12.2
 lyricsgenius==3.0.1
+meaningless==1.0.0
 pyperclip==1.8.2
 requests==2.31.0
 # These are the transitive package dependencies from the direct dependencies
 certifi==2023.11.17
 charset-normalizer==3.3.2
 idna==3.4
+ruamel.yaml==0.18.5
+ruamel.yaml.clib==0.2.8
 soupsieve==2.5
 urllib3==2.1.0
+xmltodict==0.13.0

--- a/Scripts/bible_passage.py
+++ b/Scripts/bible_passage.py
@@ -1,125 +1,49 @@
-import requests
-from bs4 import BeautifulSoup
 import pyperclip
-import re
-
-class NoTextFoundException(Exception):
-    def __init__(self, message="No text found in the file."):
-        self.message = message
-        super().__init__(self.message)
-
-def remove_letters_in_brackets(text):
-    # Use regular expression to match text within both round and square brackets (single or double character) and remove them
-    if text is None:
-        raise NoTextFoundException()
-    cleaned_text = re.sub(r'[\[\(][A-Za-z]{1,2}[\]\)]', '', text)
-    cleaned_text = re.sub(r'\(\w{2}\)', '', cleaned_text)
-    return cleaned_text
-
-def get_bible_verse(verse_reference):
-    url = f"https://www.biblegateway.com/passage/?search={verse_reference}&version=NIV"
-    
-    try:
-        response = requests.get(url)
-    except:
-        raise ConnectionError()
-    
-    print(response)
-    
-
-    soup = BeautifulSoup(response.content, 'html.parser')
-    
-    passage = soup.find("div", {"class": "passage-text"})
-    if passage:
-        verses = passage.find_all("span", {"class": "text"})
-        verse_text = " ".join([verse.get_text() for verse in verses])
-        return verse_text
-    else:
-        return None
-
-def split_verse_into_parts(verse_text, words_per_part=175, sentences_per_part = 10):
-    parts = []
-
-    verse_sentences = verse_text.split('.')
-    i = 0
-
-    for i in range(len(verse_sentences)):
-        try:
-            if (verse_sentences[i][-1] != '"'):
-                verse_sentences[i] = verse_sentences[i] + '.'
-        except:
-            pass
-        i += 1
-    
-    current_part = []
-    sentence_count = 0
-
-    for sentence in verse_sentences:
-        current_part.append(sentence)
-        sentence_count += 1
-    
-        if len(current_part) >= sentences_per_part:
-            part = " ".join(current_part)
-            parts.append(part)
-            current_part = []
-            sentence_count = 0
-    
-    
-    # for word in verse_words:
-    #     current_part.append(word)
-    #     word_count += 1
-        
-    #     if word_count >= words_per_part:
-    #         part = " ".join(current_part)
-    #         parts.append(part)
-    #         current_part = []
-    #         word_count = 0
-    
-    if current_part:
-        part = " ".join(current_part)
-        parts.append(part)
-    
-    
-    return parts
+from meaningless import WebExtractor
+from meaningless.utilities.exceptions import InvalidSearchError
 
 
 def bible_passage():
+    verse_max = 5  # The max number of verses that compose a part
+    newlines_max = 5  # The max number of lines that compose a part - 1
+
     while True:
         verse_reference = input("Enter a Bible verse reference such as '2 Peter 1:5-11' (n to exit)\n")
         
         if verse_reference.lower().strip() == "n":
             return
-        
+
         try:
-            verse_text = remove_letters_in_brackets(get_bible_verse(verse_reference))
+            extractor = WebExtractor(translation="NIV", output_as_list=True)
+            verse_text = extractor.search(verse_reference)
             break
-        except NoTextFoundException:
+        except InvalidSearchError:
             go_again = input("No text found. Would you like to try again? (Y for yes, any other key to exit)\n")
             if go_again.lower().strip() == "y":
                 continue
             else:
                 return
-        except ConnectionError:
-            go_again = input("Could not connect to the API. Check your internet connection. Would you like to try again? (Y for yes, any other key to exit)\n")
-            if go_again.lower().strip() == "y":
-                continue
-            else:
-                return
 
-
-    if verse_text:
-        # Split the verse into 5-verse long parts
-        parts = split_verse_into_parts(verse_text)
-        
-        for i, part in enumerate(parts):
+    verse_remaining = len(verse_text)
+    verse_count = 0
+    part_count = 0
+    part = ""
+    for i, verse in enumerate(verse_text):
+        part = f"{part}{verse}"
+        # This ensures each slide has a consistent number of verses
+        verse_count = (verse_count + 1) % verse_max
+        # This is kept track of to ensure a partial collection at the end is accounted for
+        verse_remaining -= 1
+        # Each part consists of either a set number of verses OR an approximate set of lines.
+        # There might be situations where a really long verse takes up an entire slide's worth of space,
+        # or the alternative where lots of verses are placed onto one slide
+        if verse_count <= 0 or verse_remaining <= 0 or part.count("\n") >= newlines_max:
+            verse_count = 0  # Need to reset the verse count in case it's the other conditions that matched
+            part_count += 1
             pyperclip.copy(part)
-            print(f"Part {i + 1} - Bible verse copied to clipboard:")
-            print(part)
-            if i < len(parts) - 1:
-                input("Press Enter to copy the next part...")
-    else:
-        print("Verse not found or error occurred.")
 
-def split_bible_text(bible_text, verses_per_part=5):
-    verses = bible_text.split('\n')
-    parts = [verses[i:i + verses_per_part] for i in range(0, len(verses), verses_per_part)]
+            print(f"Part {part_count} - Bible verse copied to clipboard:")
+            print(part)
+            part = ""
+            if verse_remaining > 0:
+                input("Press Enter to copy the next part...")


### PR DESCRIPTION
This leverages an existing library package to handle Bible verse extraction and can greatly simplify the logic in `bible_passage.py`.

Other notable changes from this include:
- Slightly nicer output by removing double spaces and preserving verse numbers as superscript characters.
- Part construction now relies on either verse count or number of newlines, instead of sentence count.
  - This should hopefully be more consistent in terms of total content per slide, since the previous implementation doesn't account for sentences that end in question marks or exclamation marks.
- Removing helper functions such as `remove_letters_in_brackets` since meaningless can more or less facilitate their functionality.